### PR TITLE
Implement feature caching and SIMD dot product

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,5 @@
 use rayon::{ThreadPool, ThreadPoolBuilder};
+use arrayvec::ArrayVec;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::chess::Move;
@@ -19,6 +20,7 @@ pub struct ThreadData<'a> {
     pub ttable: &'a LRTable,
     pub allocator: LRAllocator<'a>,
     pub playouts: usize,
+    pub path: ArrayVec<&'a MoveEdge, { crate::mcts::MAX_PLAYOUT_LENGTH }>,
 }
 
 impl<'a> ThreadData<'a> {
@@ -27,6 +29,7 @@ impl<'a> ThreadData<'a> {
             ttable,
             allocator: ttable.allocator(),
             playouts: 0,
+            path: ArrayVec::new(),
         }
     }
 }

--- a/src/evaluation.rs
+++ b/src/evaluation.rs
@@ -1,4 +1,3 @@
-use goober::SparseVector;
 
 use crate::chess::MoveList;
 use crate::math;
@@ -108,8 +107,7 @@ fn run_policy_net(_state: &State, moves: &MoveList, _t: f32) -> Vec<f32> {
 
 #[cfg(feature = "policy-net")]
 fn run_policy_net(state: &State, moves: &MoveList, t: f32) -> Vec<f32> {
-    let mut features = SparseVector::with_capacity(32);
-    state.policy_features_map(|idx| features.push(idx));
+    let features = state.policy_features();
 
     let mut evalns = vec![0.0; moves.len()];
 


### PR DESCRIPTION
## Summary
- cache policy feature vectors inside `State`
- reuse a shared path buffer for MCTS playouts
- accelerate `Accumulator::dot_relu` with SSE2 when available

## Testing
- `cargo check`
- `cargo fmt` *(fails: `cargo-fmt` missing)*
- `cargo clippy --all-targets -- -D warnings` *(fails: `cargo-clippy` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c37af65188326b360fcb03efed9c9