### PR TITLE
Reuse policy feature vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,6 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 [[package]]
 name = "goober"
 version = "0.1.0"
-source = "git+https://github.com/jw1912/goober/?rev=32b9b52#32b9b52e68ef03d9d706548fb21bb3c4535c4dd2"
 dependencies = [
  "goober-core",
  "goober-derive",
@@ -167,12 +166,10 @@ dependencies = [
 [[package]]
 name = "goober-core"
 version = "0.1.0"
-source = "git+https://github.com/jw1912/goober/?rev=32b9b52#32b9b52e68ef03d9d706548fb21bb3c4535c4dd2"
 
 [[package]]
 name = "goober-derive"
 version = "0.1.0"
-source = "git+https://github.com/jw1912/goober/?rev=32b9b52#32b9b52e68ef03d9d706548fb21bb3c4535c4dd2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -182,7 +179,6 @@ dependencies = [
 [[package]]
 name = "goober-layer"
 version = "0.1.0"
-source = "git+https://github.com/jw1912/goober/?rev=32b9b52#32b9b52e68ef03d9d706548fb21bb3c4535c4dd2"
 dependencies = [
  "goober-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ cc = "=1.0.83"
 [profile.release]
 lto = true
 debug = true
+
+[patch."https://github.com/jw1912/goober/"]
+goober = { path = "deps/goober" }

--- a/deps/goober/.gitignore
+++ b/deps/goober/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/deps/goober/Cargo.toml
+++ b/deps/goober/Cargo.toml
@@ -1,0 +1,23 @@
+[workspace]
+resolver = "2"
+members = [
+    "goober-core",
+    "goober-derive",
+    "goober-layer",
+]
+
+[workspace.package]
+license = "MIT"
+authors = ["Jamie Whiting"]
+
+[package]
+name = "goober"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+goober-core = { path = "goober-core" }
+goober-derive = { path = "goober-derive" }
+goober-layer = { path = "goober-layer" }

--- a/deps/goober/LICENSE
+++ b/deps/goober/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Jamie Whiting
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/deps/goober/README.md
+++ b/deps/goober/README.md
@@ -1,0 +1,9 @@
+<div align="center">
+
+# goober
+
+![License](https://img.shields.io/github/license/jw1912/goober?style=for-the-badge)
+
+</div>
+
+A Feed-Forward Neural Network Library.

--- a/deps/goober/goober-core/Cargo.toml
+++ b/deps/goober/goober-core/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "goober-core"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+authors.workspace = true

--- a/deps/goober/goober-core/src/activation.rs
+++ b/deps/goober/goober-core/src/activation.rs
@@ -1,0 +1,63 @@
+pub trait Activation: Copy {
+    fn activate(x: f32) -> f32;
+
+    fn derivative(x: f32) -> f32;
+}
+
+#[derive(Clone, Copy)]
+pub struct Identity;
+impl Activation for Identity {
+    fn activate(x: f32) -> f32 {
+        x
+    }
+
+    fn derivative(_: f32) -> f32 {
+        1.0
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct ReLU;
+impl Activation for ReLU {
+    fn activate(x: f32) -> f32 {
+        x.max(0.0)
+    }
+
+    fn derivative(x: f32) -> f32 {
+        if x > 0.0 {
+            1.0
+        } else {
+            0.0
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct SCReLU;
+impl Activation for SCReLU {
+    fn activate(x: f32) -> f32 {
+        let clamped = x.clamp(0.0, 1.0);
+        clamped * clamped
+    }
+
+    fn derivative(x: f32) -> f32 {
+        if 0.0 < x && x < 1.0 {
+            2.0 * x
+        } else {
+            0.0
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Tanh;
+impl Activation for Tanh {
+    fn activate(x: f32) -> f32 {
+        x.tanh()
+    }
+
+    fn derivative(x: f32) -> f32 {
+        let t = x.tanh();
+        1.0 - t * t
+    }
+}

--- a/deps/goober/goober-core/src/lib.rs
+++ b/deps/goober/goober-core/src/lib.rs
@@ -1,0 +1,56 @@
+pub mod activation;
+mod matrix;
+mod vector;
+
+pub use matrix::Matrix;
+pub use vector::{SparseVector, Vector};
+
+pub trait OutputLayer<OutputType> {
+    fn output_layer(&self) -> OutputType;
+}
+
+pub trait FeedForwardNetwork: Sized {
+    type InputType: Clone;
+    type OutputType: Clone;
+    type Layers: OutputLayer<Self::OutputType>;
+
+    fn adam(&mut self, g: &Self, m: &mut Self, v: &mut Self, adj: f32, lr: f32);
+
+    fn boxed_and_zeroed() -> Box<Self> {
+        unsafe {
+            let layout = std::alloc::Layout::new::<Self>();
+            let ptr = std::alloc::alloc_zeroed(layout);
+            if ptr.is_null() {
+                std::alloc::handle_alloc_error(layout);
+            }
+            Box::from_raw(ptr.cast())
+        }
+    }
+
+    fn write_to_bin(&self, path: &str) {
+        use std::io::Write;
+
+        let mut file = std::fs::File::create(path).unwrap();
+
+        unsafe {
+            let ptr: *const Self = self;
+            let slice_ptr: *const u8 = std::mem::transmute(ptr);
+            let slice = std::slice::from_raw_parts(slice_ptr, std::mem::size_of_val(self));
+            file.write_all(slice).unwrap();
+        }
+    }
+
+    fn out_with_layers(&self, input: &Self::InputType) -> Self::Layers;
+
+    fn out(&self, input: &Self::InputType) -> Self::OutputType {
+        self.out_with_layers(input).output_layer()
+    }
+
+    fn backprop(
+        &self,
+        input: &Self::InputType,
+        grad: &mut Self,
+        out_err: Self::OutputType,
+        layers: &Self::Layers,
+    ) -> Self::InputType;
+}

--- a/deps/goober/goober-core/src/matrix.rs
+++ b/deps/goober/goober-core/src/matrix.rs
@@ -1,0 +1,76 @@
+use crate::Vector;
+
+/// `N`x`M` Matrix Type.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Matrix<const M: usize, const N: usize> {
+    inner: [Vector<N>; M],
+}
+
+impl<const M: usize, const N: usize> std::ops::AddAssign<&Matrix<M, N>> for Matrix<M, N> {
+    fn add_assign(&mut self, rhs: &Matrix<M, N>) {
+        for (u, v) in self.inner.iter_mut().zip(rhs.inner.iter()) {
+            *u += *v;
+        }
+    }
+}
+
+impl<const M: usize, const N: usize> std::ops::Deref for Matrix<M, N> {
+    type Target = [Vector<N>; M];
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<const M: usize, const N: usize> std::ops::DerefMut for Matrix<M, N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<const M: usize, const N: usize> Matrix<M, N> {
+    pub const fn zeroed() -> Self {
+        Self::from_raw([Vector::zeroed(); M])
+    }
+
+    pub const fn from_raw(inner: [Vector<N>; M]) -> Self {
+        Self { inner }
+    }
+
+    pub fn from_fn<F: FnMut(usize, usize) -> f32>(mut f: F) -> Self {
+        let mut rows = [Vector::zeroed(); M];
+
+        for (i, row) in rows.iter_mut().enumerate() {
+            let inner_f = |j| f(i, j);
+            *row = Vector::from_fn(inner_f);
+        }
+
+        Self::from_raw(rows)
+    }
+
+    pub fn mul(&self, inp: &Vector<M>) -> Vector<N> {
+        let mut result = Vector::zeroed();
+
+        for i in 0..M {
+            result.madd(&self.inner[i], inp[i]);
+        }
+
+        result
+    }
+
+    pub fn transpose_mul(&self, out: &Vector<N>) -> Vector<M> {
+        Vector::from_fn(|i| {
+            let mut v = 0.0;
+            for j in 0..N {
+                v += self.inner[i][j] * out[j];
+            }
+            v
+        })
+    }
+
+    pub fn adam(&mut self, g: &Self, m: &mut Self, v: &mut Self, adj: f32, lr: f32) {
+        for i in 0..M {
+            self.inner[i].adam(g.inner[i], &mut m.inner[i], &mut v.inner[i], adj, lr);
+        }
+    }
+}

--- a/deps/goober/goober-core/src/vector.rs
+++ b/deps/goober/goober-core/src/vector.rs
@@ -1,0 +1,210 @@
+use crate::activation::Activation;
+
+/// Sparse representation of a vector, storing active
+/// indices instead of a value for each index in the vector.
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SparseVector {
+    inner: Vec<usize>,
+}
+
+impl std::ops::Add<SparseVector> for SparseVector {
+    type Output = SparseVector;
+    fn add(mut self, mut rhs: SparseVector) -> Self::Output {
+        self.inner.append(&mut rhs.inner);
+        self
+    }
+}
+
+impl std::ops::Deref for SparseVector {
+    type Target = [usize];
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl SparseVector {
+    pub fn with_capacity(cap: usize) -> Self {
+        Self {
+            inner: Vec::with_capacity(cap),
+        }
+    }
+
+    pub fn push(&mut self, val: usize) {
+        self.inner.push(val);
+    }
+
+    /// Remove all elements from the vector without deallocating.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+}
+
+/// `N`-Dimensional Vector Type.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Vector<const N: usize> {
+    inner: [f32; N],
+}
+
+impl<const N: usize> std::ops::Index<usize> for Vector<N> {
+    type Output = f32;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.inner[index]
+    }
+}
+
+impl<const N: usize> std::ops::IndexMut<usize> for Vector<N> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.inner[index]
+    }
+}
+
+impl<const N: usize> std::ops::Add<Vector<N>> for Vector<N> {
+    type Output = Vector<N>;
+    fn add(mut self, rhs: Vector<N>) -> Self::Output {
+        for (i, j) in self.inner.iter_mut().zip(rhs.inner.iter()) {
+            *i += *j;
+        }
+
+        self
+    }
+}
+
+impl<const N: usize> std::ops::Add<f32> for Vector<N> {
+    type Output = Vector<N>;
+    fn add(mut self, rhs: f32) -> Self::Output {
+        for i in self.inner.iter_mut() {
+            *i += rhs;
+        }
+
+        self
+    }
+}
+
+impl<const N: usize> std::ops::AddAssign<Vector<N>> for Vector<N> {
+    fn add_assign(&mut self, rhs: Vector<N>) {
+        for (i, j) in self.inner.iter_mut().zip(rhs.inner.iter()) {
+            *i += *j;
+        }
+    }
+}
+
+impl<const N: usize> std::ops::Div<Vector<N>> for Vector<N> {
+    type Output = Vector<N>;
+    fn div(mut self, rhs: Vector<N>) -> Self::Output {
+        for (i, j) in self.inner.iter_mut().zip(rhs.inner.iter()) {
+            *i /= *j;
+        }
+
+        self
+    }
+}
+
+impl<const N: usize> std::ops::Mul<Vector<N>> for Vector<N> {
+    type Output = Vector<N>;
+    fn mul(mut self, rhs: Vector<N>) -> Self::Output {
+        for (i, j) in self.inner.iter_mut().zip(rhs.inner.iter()) {
+            *i *= *j;
+        }
+
+        self
+    }
+}
+
+impl<const N: usize> std::ops::Mul<Vector<N>> for f32 {
+    type Output = Vector<N>;
+    fn mul(self, mut rhs: Vector<N>) -> Self::Output {
+        for i in rhs.inner.iter_mut() {
+            *i *= self;
+        }
+
+        rhs
+    }
+}
+
+impl<const N: usize> std::ops::SubAssign<Vector<N>> for Vector<N> {
+    fn sub_assign(&mut self, rhs: Vector<N>) {
+        for (i, j) in self.inner.iter_mut().zip(rhs.inner.iter()) {
+            *i -= *j;
+        }
+    }
+}
+
+impl<const N: usize> Vector<N> {
+    pub fn from_fn<F: FnMut(usize) -> f32>(mut f: F) -> Self {
+        let mut res = Self::zeroed();
+
+        for i in 0..N {
+            res.inner[i] = f(i);
+        }
+
+        res
+    }
+
+    pub fn dot(&self, other: &Vector<N>) -> f32 {
+        let mut score = 0.0;
+        for (&i, &j) in self.inner.iter().zip(other.inner.iter()) {
+            score += i * j;
+        }
+
+        score
+    }
+
+    pub fn out<T: Activation>(&self, other: &Vector<N>) -> f32 {
+        let mut score = 0.0;
+        for (i, j) in self.inner.iter().zip(other.inner.iter()) {
+            score += T::activate(*i) * T::activate(*j);
+        }
+
+        score
+    }
+
+    pub fn sqrt(mut self) -> Self {
+        for i in self.inner.iter_mut() {
+            *i = i.sqrt();
+        }
+
+        self
+    }
+
+    pub const fn from_raw(inner: [f32; N]) -> Self {
+        Self { inner }
+    }
+
+    pub const fn zeroed() -> Self {
+        Self::from_raw([0.0; N])
+    }
+
+    pub fn activate<T: Activation>(mut self) -> Self {
+        for i in self.inner.iter_mut() {
+            *i = T::activate(*i);
+        }
+
+        self
+    }
+
+    pub fn derivative<T: Activation>(mut self) -> Self {
+        for i in self.inner.iter_mut() {
+            *i = T::derivative(*i);
+        }
+
+        self
+    }
+
+    pub fn adam(&mut self, mut g: Self, m: &mut Self, v: &mut Self, adj: f32, lr: f32) {
+        const B1: f32 = 0.9;
+        const B2: f32 = 0.999;
+
+        g = adj * g;
+        *m = B1 * *m + (1. - B1) * g;
+        *v = B2 * *v + (1. - B2) * g * g;
+        *self -= lr * *m / (v.sqrt() + 0.000_000_01);
+    }
+
+    pub fn madd(&mut self, other: &Self, mul: f32) {
+        for (i, j) in self.inner.iter_mut().zip(other.inner.iter()) {
+            *i += mul * *j;
+        }
+    }
+}

--- a/deps/goober/goober-derive/Cargo.toml
+++ b/deps/goober/goober-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "goober-derive"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+authors.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.70"
+quote = "1.0.33"
+syn = "2.0.39"

--- a/deps/goober/goober-derive/src/lib.rs
+++ b/deps/goober/goober-derive/src/lib.rs
@@ -1,0 +1,190 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields};
+
+#[proc_macro_derive(FeedForwardNetwork)]
+pub fn network_utils(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+    let layer_name = Ident::new((name.to_string() + "Layer").as_str(), Span::call_site());
+
+    let add_impl = gen_add_impl(&input.data);
+    let layer_fields = gen_layer_fields(&input.data);
+
+    let input_type = gen_input_type(&input.data);
+    let output_type = gen_output_type(&input.data);
+    let output_layer = gen_output_layer(&input.data);
+
+    let adam_expr = gen_adam_expr(&input.data);
+    let layer_exprs = gen_layer_exprs(&input.data);
+    let layer_exprs_fields = gen_layer_exprs_fields(&input.data);
+    let backprop_exprs = gen_backprop_exprs(&input.data);
+
+    let expanded = quote! {
+        impl std::ops::AddAssign<& #name> for #name {
+            fn add_assign(&mut self, rhs: & #name) {
+                #add_impl
+            }
+        }
+
+        pub struct #layer_name {
+            #layer_fields
+        }
+
+        impl goober::OutputLayer<#output_type> for #layer_name {
+            #output_layer
+        }
+
+        impl goober::FeedForwardNetwork for #name {
+            type InputType = #input_type;
+            type OutputType = #output_type;
+            type Layers = #layer_name;
+
+            fn adam(&mut self, g: &Self, m: &mut Self, v: &mut Self, adj: f32, lr: f32) {
+                #adam_expr
+            }
+
+            fn out_with_layers(&self, input: &Self::InputType) -> Self::Layers {
+                use goober::OutputLayer as __InternalOutputLayer;
+                #layer_exprs
+                Self::Layers {
+                    #layer_exprs_fields
+                }
+            }
+
+            fn backprop(
+                &self,
+                input: &Self::InputType,
+                grad: &mut Self,
+                err: Self::OutputType,
+                layers: &Self::Layers,
+            ) -> Self::InputType {
+                use goober::OutputLayer as __InternalOutputLayer;
+                #backprop_exprs
+            }
+        }
+    };
+
+    proc_macro::TokenStream::from(expanded)
+}
+
+macro_rules! struct_with_fields_only {
+    (|$data:ident, $fields:ident| $thing:expr) => {{
+        match *$data {
+            Data::Struct(ref $data) => match $data.$fields {
+                Fields::Named(ref $fields) => $thing,
+                _ => unimplemented!(),
+            },
+            Data::Enum(_) | Data::Union(_) => unimplemented!(),
+        }
+    }};
+}
+
+fn gen_add_impl(data: &Data) -> TokenStream {
+    struct_with_fields_only!(|data, fields| {
+        let recurse = fields.named.iter().map(|f| {
+            let name = &f.ident;
+            quote!(self.#name += &rhs.#name;)
+        });
+        quote!(#(#recurse)*)
+    })
+}
+
+fn gen_layer_fields(data: &Data) -> TokenStream {
+    struct_with_fields_only!(|data, fields| {
+        let recurse = fields.named.iter().map(|f| {
+            let name = &f.ident;
+            let ty = &f.ty;
+            quote!(#name: <#ty as goober::FeedForwardNetwork>::Layers,)
+        });
+        quote!(#(#recurse)*)
+    })
+}
+
+fn gen_output_type(data: &Data) -> TokenStream {
+    struct_with_fields_only!(|data, fields| {
+        let f1 = fields.named.last().unwrap();
+        let ty = &f1.ty;
+        quote! {
+            <#ty as goober::FeedForwardNetwork>::OutputType
+        }
+    })
+}
+
+fn gen_output_layer(data: &Data) -> TokenStream {
+    struct_with_fields_only!(|data, fields| {
+        let f1 = fields.named.last().unwrap();
+        let name = &f1.ident;
+        let ty = &f1.ty;
+        quote! {
+            fn output_layer(&self) -> <#ty as goober::FeedForwardNetwork>::OutputType {
+                self.#name.output_layer()
+            }
+        }
+    })
+}
+
+fn gen_input_type(data: &Data) -> TokenStream {
+    struct_with_fields_only!(|data, fields| {
+        let f1 = fields.named.first().unwrap();
+        let ty = &f1.ty;
+        quote!(<#ty as goober::FeedForwardNetwork>::InputType)
+    })
+}
+
+fn gen_adam_expr(data: &Data) -> TokenStream {
+    struct_with_fields_only!(|data, fields| {
+        let recurse = fields.named.iter().map(|f| {
+            let name = &f.ident;
+            quote!(self.#name.adam(&g.#name, &mut m.#name, &mut v.#name, adj, lr);)
+        });
+        quote!(#(#recurse)*)
+    })
+}
+
+fn gen_layer_exprs(data: &Data) -> TokenStream {
+    struct_with_fields_only!(|data, fields| {
+        let mut prev = &None;
+        let recurse = fields.named.iter().enumerate().map(|(i, f)| {
+            let name = &f.ident;
+            let res = if i > 0 {
+                quote!(let #name = self.#name.out_with_layers(&#prev.output_layer());)
+            } else {
+                quote!(let #name = self.#name.out_with_layers(input);)
+            };
+            prev = name;
+            res
+        });
+        quote!(#(#recurse)*)
+    })
+}
+
+fn gen_layer_exprs_fields(data: &Data) -> TokenStream {
+    struct_with_fields_only!(|data, fields| {
+        let recurse = fields.named.iter().map(|f| {
+            let name = &f.ident;
+            quote!(#name,)
+        });
+        quote!(#(#recurse)*)
+    })
+}
+
+fn gen_backprop_exprs(data: &Data) -> TokenStream {
+    struct_with_fields_only!(|data, fields| {
+        let mut prev = &None;
+        let mut list = fields.named.iter().enumerate().map(|(i, f)| {
+                let name = &f.ident;
+                let res = if i > 0 {
+                    quote!(let err = self.#name.backprop(&layers.#prev.output_layer(), &mut grad.#name, err, &layers.#name);)
+                } else {
+                    quote!(self.#name.backprop(input, &mut grad.#name, err, &layers.#name))
+                };
+
+                prev = name;
+                res
+            }).collect::<Vec<TokenStream>>();
+        list.reverse();
+        let recurse = list.into_iter();
+        quote!(#(#recurse)*)
+    })
+}

--- a/deps/goober/goober-layer/Cargo.toml
+++ b/deps/goober/goober-layer/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "goober-layer"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+goober-core = { path = "../goober-core" }

--- a/deps/goober/goober-layer/src/add.rs
+++ b/deps/goober/goober-layer/src/add.rs
@@ -1,0 +1,84 @@
+use goober_core::{FeedForwardNetwork, OutputLayer};
+
+/// Adds two sub-networks that have common inputs and outputs.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Add<A, B> {
+    a: A,
+    b: B,
+}
+
+impl<A, B> std::ops::AddAssign<&Add<A, B>> for Add<A, B>
+where
+    for<'a> A: FeedForwardNetwork + std::ops::AddAssign<&'a A>,
+    for<'a> B: FeedForwardNetwork + std::ops::AddAssign<&'a B>,
+{
+    fn add_assign(&mut self, rhs: &Add<A, B>) {
+        self.a += &rhs.a;
+        self.b += &rhs.b;
+    }
+}
+
+pub struct AddLayers<A, B>
+where
+    A: FeedForwardNetwork,
+    B: FeedForwardNetwork,
+{
+    a: A::Layers,
+    b: B::Layers,
+}
+
+impl<A, B> OutputLayer<A::OutputType> for AddLayers<A, B>
+where
+    A: FeedForwardNetwork,
+    B: FeedForwardNetwork<OutputType = A::OutputType>,
+    A::OutputType: std::ops::Add<A::OutputType, Output = A::OutputType>,
+{
+    fn output_layer(&self) -> A::OutputType {
+        self.a.output_layer() + self.b.output_layer()
+    }
+}
+
+impl<A, B> FeedForwardNetwork for Add<A, B>
+where
+    A: FeedForwardNetwork,
+    B: FeedForwardNetwork<InputType = A::InputType, OutputType = A::OutputType>,
+    A::OutputType: std::ops::Add<A::OutputType, Output = A::OutputType>,
+    A::InputType: std::ops::Add<A::InputType, Output = A::InputType>,
+{
+    type InputType = A::InputType;
+    type OutputType = A::OutputType;
+    type Layers = AddLayers<A, B>;
+
+    fn adam(&mut self, g: &Self, m: &mut Self, v: &mut Self, adj: f32, lr: f32) {
+        self.a.adam(&g.a, &mut m.a, &mut v.a, adj, lr);
+        self.b.adam(&g.b, &mut m.b, &mut v.b, adj, lr);
+    }
+
+    fn out_with_layers(&self, input: &Self::InputType) -> Self::Layers {
+        Self::Layers {
+            a: self.a.out_with_layers(input),
+            b: self.b.out_with_layers(input),
+        }
+    }
+
+    fn backprop(
+        &self,
+        input: &Self::InputType,
+        grad: &mut Self,
+        out_err: Self::OutputType,
+        layers: &Self::Layers,
+    ) -> Self::InputType {
+        let a_back = self
+            .a
+            .backprop(input, &mut grad.a, out_err.clone(), &layers.a);
+        let b_back = self.b.backprop(input, &mut grad.b, out_err, &layers.b);
+        a_back + b_back
+    }
+}
+
+impl<A, B> Add<A, B> {
+    pub const fn from_raw(a: A, b: B) -> Self {
+        Self { a, b }
+    }
+}

--- a/deps/goober/goober-layer/src/conv1d.rs
+++ b/deps/goober/goober-layer/src/conv1d.rs
@@ -1,0 +1,98 @@
+use std::marker::PhantomData;
+
+use goober_core::{FeedForwardNetwork, OutputLayer, Vector, activation::Activation};
+
+/// Applies a 1D Convolution from input dimension `M` to output dimension `N`.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Conv1D<T, const M: usize, const N: usize> {
+    weights: Vector<M>,
+    bias: Vector<N>,
+    phantom: PhantomData<T>,
+}
+
+impl<T, const M: usize, const N: usize> std::ops::AddAssign<&Conv1D<T, M, N>> for Conv1D<T, M, N> {
+    fn add_assign(&mut self, rhs: &Conv1D<T, M, N>) {
+        self.weights += rhs.weights;
+        self.bias += rhs.bias;
+    }
+}
+
+impl<T, const M: usize, const N: usize> Conv1D<T, M, N> {
+    pub fn from_raw(weights: Vector<M>, bias: Vector<N>) -> Self {
+        Self { weights, bias, phantom: PhantomData }
+    }
+
+    pub const fn zeroed() -> Self {
+        Self { weights: Vector::zeroed(), bias: Vector::zeroed(), phantom: PhantomData }
+    }
+}
+
+pub struct Conv1DLayers<const N: usize> {
+    out: Vector<N>,
+}
+
+impl<const N: usize> OutputLayer<Vector<N>> for Conv1DLayers<N> {
+    fn output_layer(&self) -> Vector<N> {
+        self.out
+    }
+}
+
+impl<T, const M: usize, const N: usize> FeedForwardNetwork for Conv1D<T, M, N>
+where T: Activation
+{
+    type InputType = Vector<M>;
+    type OutputType = Vector<N>;
+    type Layers = Conv1DLayers<N>;
+
+    fn adam(&mut self, g: &Self, m: &mut Self, v: &mut Self, adj: f32, lr: f32) {
+        self.weights.adam(g.weights, &mut m.weights, &mut v.weights, adj, lr);
+        self.bias.adam(g.bias, &mut m.bias, &mut v.bias, adj, lr);
+    }
+
+    fn backprop(
+        &self,
+        input: &Vector<M>,
+        grad: &mut Self,
+        mut out_err: Vector<N>,
+        layers: &Conv1DLayers<N>,
+    ) -> Vector<M> {
+        let k = M - N + 1;
+        out_err = out_err * layers.out.derivative::<T>();
+
+        grad.bias += out_err;
+
+        for i in 0..N {
+            for j in 0..k {
+                grad.weights[j] += out_err[i] * input[i + j];
+            }
+        }
+
+        Vector::from_fn(|i| {
+            let mut val = 0.0;
+            for j in 0..k {
+                let elem = if i < k - 1 || i >= N + k - 1 {
+                    0.0
+                } else {
+                    out_err[i - k + 1] * self.weights[j]
+                };
+                val += elem;
+            }
+            val
+        })
+    }
+
+    fn out_with_layers(&self, input: &Vector<M>) -> Conv1DLayers<N> {
+        let k = M - N + 1;
+
+        let out = Vector::from_fn(|i| {
+            let mut val = self.bias[i];
+            for j in 0..k {
+                val += input[i + j] * self.weights[j];
+            }
+            val
+        });
+
+        Conv1DLayers { out: out.activate::<T>() }
+    }
+}

--- a/deps/goober/goober-layer/src/dense.rs
+++ b/deps/goober/goober-layer/src/dense.rs
@@ -1,0 +1,146 @@
+use std::marker::PhantomData;
+
+use goober_core::{activation::Activation, FeedForwardNetwork, Matrix, OutputLayer, Vector};
+
+/// Fully-Connected layer.
+/// - `T` is the activation function used.
+/// - `M` is the size of the input vector.
+/// - `N` is the size of the output vector.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct DenseConnected<T: Activation, const M: usize, const N: usize> {
+    weights: Matrix<M, N>,
+    bias: Vector<N>,
+    phantom: PhantomData<T>,
+}
+
+impl<T: Activation, const M: usize, const N: usize> std::ops::AddAssign<&DenseConnected<T, M, N>>
+    for DenseConnected<T, M, N>
+{
+    fn add_assign(&mut self, rhs: &DenseConnected<T, M, N>) {
+        self.weights += &rhs.weights;
+        self.bias += rhs.bias;
+    }
+}
+
+impl<T: Activation, const M: usize, const N: usize> DenseConnected<T, M, N> {
+    pub const INPUT_SIZE: usize = M;
+    pub const OUTPUT_SIZE: usize = N;
+
+    pub fn weights_col(&self, idx: usize) -> &Vector<N> {
+        &self.weights[idx]
+    }
+
+    pub fn weights_col_mut(&mut self, idx: usize) -> &mut Vector<N> {
+        &mut self.weights[idx]
+    }
+
+    pub fn bias(&self) -> Vector<N> {
+        self.bias
+    }
+
+    pub fn bias_mut(&mut self) -> &mut Vector<N> {
+        &mut self.bias
+    }
+
+    pub const fn zeroed() -> Self {
+        Self::from_raw(Matrix::zeroed(), Vector::zeroed())
+    }
+
+    pub const fn from_raw(weights: Matrix<M, N>, bias: Vector<N>) -> Self {
+        Self {
+            weights,
+            bias,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn from_fn<W: FnMut(usize, usize) -> f32, B: FnMut(usize) -> f32>(w: W, b: B) -> Self {
+        Self {
+            weights: Matrix::from_fn(w),
+            bias: Vector::from_fn(b),
+            phantom: PhantomData,
+        }
+    }
+}
+
+pub struct DenseConnectedLayers<const N: usize> {
+    out: Vector<N>,
+}
+
+impl<const N: usize> OutputLayer<Vector<N>> for DenseConnectedLayers<N> {
+    fn output_layer(&self) -> Vector<N> {
+        self.out
+    }
+}
+
+impl<T: Activation, const M: usize, const N: usize> FeedForwardNetwork for DenseConnected<T, M, N> {
+    type InputType = Vector<M>;
+    type OutputType = Vector<N>;
+    type Layers = DenseConnectedLayers<N>;
+
+    fn adam(&mut self, g: &Self, m: &mut Self, v: &mut Self, adj: f32, lr: f32) {
+        self.weights
+            .adam(&g.weights, &mut m.weights, &mut v.weights, adj, lr);
+
+        self.bias.adam(g.bias, &mut m.bias, &mut v.bias, adj, lr);
+    }
+
+    fn out_with_layers(&self, input: &Self::InputType) -> Self::Layers {
+        Self::Layers {
+            out: (self.weights.mul(input) + self.bias).activate::<T>(),
+        }
+    }
+
+    fn backprop(
+        &self,
+        input: &Self::InputType,
+        grad: &mut Self,
+        mut out_err: Self::OutputType,
+        layers: &Self::Layers,
+    ) -> Self::InputType {
+        out_err = out_err * layers.out.derivative::<T>();
+
+        for (i, row) in grad.weights.iter_mut().enumerate() {
+            row.madd(&out_err, input[i]);
+        }
+
+        grad.bias += out_err;
+        self.weights.transpose_mul(&out_err)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::DenseConnected;
+
+    #[test]
+    fn dense_connected() {
+        use goober_core::{activation::ReLU, FeedForwardNetwork, Matrix, Vector};
+
+        let layer: DenseConnected<ReLU, 3, 3> = DenseConnected::from_raw(
+            Matrix::from_raw([
+                Vector::from_raw([1.0, 1.0, 1.0]),
+                Vector::from_raw([1.0, 1.0, 0.0]),
+                Vector::from_raw([0.0, 1.0, 1.0]),
+            ]),
+            Vector::from_raw([0.1, 0.1, 0.2]),
+        );
+
+        let inputs = [
+            Vector::from_raw([1.0, 0.0, 0.0]),
+            Vector::from_raw([1.0, 1.0, 1.0]),
+            Vector::from_raw([5.0, 3.0, -2.0]),
+        ];
+
+        let expected = [
+            Vector::from_raw([1.1, 1.1, 1.2]),
+            Vector::from_raw([2.1, 3.1, 2.2]),
+            Vector::from_raw([8.1, 6.1, 3.2]),
+        ];
+
+        for (i, &e) in inputs.iter().zip(expected.iter()) {
+            assert_eq!(e, layer.out(i));
+        }
+    }
+}

--- a/deps/goober/goober-layer/src/lib.rs
+++ b/deps/goober/goober-layer/src/lib.rs
@@ -1,0 +1,9 @@
+mod add;
+mod conv1d;
+mod dense;
+mod sparse;
+
+pub use add::Add;
+pub use conv1d::Conv1D;
+pub use dense::DenseConnected;
+pub use sparse::SparseConnected;

--- a/deps/goober/goober-layer/src/sparse.rs
+++ b/deps/goober/goober-layer/src/sparse.rs
@@ -1,0 +1,151 @@
+use std::marker::PhantomData;
+
+use goober_core::{
+    activation::Activation, FeedForwardNetwork, Matrix, OutputLayer, SparseVector, Vector,
+};
+
+/// Fully-Connected layer with sparse input.
+/// - `T` is the activation function used.
+/// - `M` is the size of the input vector.
+/// - `N` is the size of the output vector.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SparseConnected<T: Activation, const M: usize, const N: usize> {
+    weights: Matrix<M, N>,
+    bias: Vector<N>,
+    phantom: PhantomData<T>,
+}
+
+impl<T: Activation, const M: usize, const N: usize> std::ops::AddAssign<&SparseConnected<T, M, N>>
+    for SparseConnected<T, M, N>
+{
+    fn add_assign(&mut self, rhs: &SparseConnected<T, M, N>) {
+        self.weights += &rhs.weights;
+        self.bias += rhs.bias;
+    }
+}
+
+impl<T: Activation, const M: usize, const N: usize> SparseConnected<T, M, N> {
+    pub fn weights_row(&self, idx: usize) -> Vector<N> {
+        self.weights[idx]
+    }
+
+    pub fn weights_row_mut(&mut self, idx: usize) -> &mut Vector<N> {
+        &mut self.weights[idx]
+    }
+
+    pub fn bias(&self) -> Vector<N> {
+        self.bias
+    }
+
+    pub fn bias_mut(&mut self) -> &mut Vector<N> {
+        &mut self.bias
+    }
+
+    pub const fn zeroed() -> Self {
+        Self::from_raw(Matrix::zeroed(), Vector::zeroed())
+    }
+
+    pub const fn from_raw(weights: Matrix<M, N>, bias: Vector<N>) -> Self {
+        Self {
+            weights,
+            bias,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn from_fn<W: FnMut(usize, usize) -> f32, B: FnMut(usize) -> f32>(w: W, b: B) -> Self {
+        Self {
+            weights: Matrix::from_fn(w),
+            bias: Vector::from_fn(b),
+            phantom: PhantomData,
+        }
+    }
+}
+
+pub struct SparseConnectedLayers<const N: usize> {
+    out: Vector<N>,
+}
+
+impl<const N: usize> OutputLayer<Vector<N>> for SparseConnectedLayers<N> {
+    fn output_layer(&self) -> Vector<N> {
+        self.out
+    }
+}
+
+impl<T: Activation, const M: usize, const N: usize> FeedForwardNetwork
+    for SparseConnected<T, M, N>
+{
+    type InputType = SparseVector;
+    type OutputType = Vector<N>;
+    type Layers = SparseConnectedLayers<N>;
+
+    fn adam(&mut self, grad: &Self, momentum: &mut Self, velocity: &mut Self, adj: f32, lr: f32) {
+        self.weights.adam(
+            &grad.weights,
+            &mut momentum.weights,
+            &mut velocity.weights,
+            adj,
+            lr,
+        );
+
+        self.bias
+            .adam(grad.bias, &mut momentum.bias, &mut velocity.bias, adj, lr);
+    }
+
+    fn out_with_layers(&self, input: &Self::InputType) -> Self::Layers {
+        let mut res = self.bias;
+
+        for &feat in input.iter() {
+            res += self.weights[feat];
+        }
+
+        Self::Layers {
+            out: res.activate::<T>(),
+        }
+    }
+
+    fn backprop(
+        &self,
+        input: &Self::InputType,
+        grad: &mut Self,
+        mut out_err: Self::OutputType,
+        layers: &Self::Layers,
+    ) -> Self::InputType {
+        out_err = out_err * layers.out.derivative::<T>();
+
+        for &feat in input.iter() {
+            grad.weights[feat] += out_err;
+        }
+
+        grad.bias += out_err;
+        SparseVector::with_capacity(0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::SparseConnected;
+
+    #[test]
+    fn sparse_connected() {
+        use goober_core::{activation::ReLU, FeedForwardNetwork, Matrix, SparseVector, Vector};
+
+        let layer: SparseConnected<ReLU, 3, 3> = SparseConnected::from_raw(
+            Matrix::from_raw([
+                Vector::from_raw([1.0, 1.0, 0.0]),
+                Vector::from_raw([1.0, 1.0, 1.0]),
+                Vector::from_raw([1.0, 0.0, 1.0]),
+            ]),
+            Vector::from_raw([0.1, 0.1, 0.2]),
+        );
+
+        let mut input = SparseVector::with_capacity(8);
+        input.push(0);
+        input.push(1);
+        input.push(2);
+
+        let expected = Vector::from_raw([3.1, 2.1, 2.2]);
+        assert_eq!(expected, layer.out(&input));
+    }
+}

--- a/deps/goober/src/lib.rs
+++ b/deps/goober/src/lib.rs
@@ -1,0 +1,3 @@
+pub use goober_core::{activation, FeedForwardNetwork, Matrix, OutputLayer, SparseVector, Vector};
+pub use goober_derive::FeedForwardNetwork;
+pub use goober_layer as layer;

--- a/deps/goober/tests/add.rs
+++ b/deps/goober/tests/add.rs
@@ -1,0 +1,25 @@
+use goober::{
+    activation::ReLU,
+    layer::{Add, DenseConnected, SparseConnected},
+    FeedForwardNetwork, SparseVector,
+};
+
+#[derive(FeedForwardNetwork)]
+pub struct TestNet {
+    l1: Add<SparseConnected<ReLU, 768, 1>, SubTestNet>,
+}
+
+#[derive(FeedForwardNetwork)]
+pub struct SubTestNet {
+    l1: SparseConnected<ReLU, 768, 16>,
+    l2: DenseConnected<ReLU, 16, 1>,
+}
+
+#[test]
+fn add() {
+    let net = TestNet::boxed_and_zeroed();
+
+    let mut input = SparseVector::with_capacity(8);
+    input.push(5);
+    let _ = net.out(&input);
+}

--- a/deps/goober/tests/connected.rs
+++ b/deps/goober/tests/connected.rs
@@ -1,0 +1,26 @@
+use goober::{
+    activation::ReLU,
+    layer::{DenseConnected, SparseConnected},
+    FeedForwardNetwork, SparseVector,
+};
+
+#[derive(FeedForwardNetwork)]
+pub struct TestNet {
+    l1: SparseConnected<ReLU, 768, 32>,
+    l2: SubTestNet,
+}
+
+#[derive(FeedForwardNetwork)]
+pub struct SubTestNet {
+    l1: DenseConnected<ReLU, 32, 16>,
+    l2: DenseConnected<ReLU, 16, 1>,
+}
+
+#[test]
+fn connected() {
+    let net = TestNet::boxed_and_zeroed();
+
+    let mut input = SparseVector::with_capacity(8);
+    input.push(5);
+    let _ = net.out(&input);
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -34,9 +34,9 @@ impl State {
     }
 
     fn update_policy_features(&mut self) {
-        let mut vec = SparseVector::with_capacity(32);
-        self.policy_features_map(|idx| vec.push(idx));
-        self.policy_features = vec;
+        self.policy_features.clear();
+        let pf_ptr: *mut SparseVector = &mut self.policy_features;
+        self.policy_features_map(|idx| unsafe { (*pf_ptr).push(idx) });
     }
 
     #[must_use]


### PR DESCRIPTION
## Summary
- patch local `goober` crate to expose `SparseVector::clear`
- reuse `policy_features` buffer in `State::update_policy_features`
- use a `[patch]` section to point to the vendored crate

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684c5140f03c832687c16435b15e5b71